### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,41 @@
+name: Build and Deploy Demo
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Publish demo
+        run: dotnet publish src/DuckDbDemo/DuckDbDemo.csproj -c Release -o build
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/wwwroot
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ type-casting functions such as `tostring()`, `toint()`, `tolong()`, `todouble()`
 against DuckDB in the unit tests using
 StormEvents data downloaded from NOAA.
 
+## Demo
+
+A Blazor WebAssembly demo in `src/DuckDbDemo` is automatically built and deployed to GitHub Pages using a GitHub Actions workflow defined in `.github/workflows/deploy-demo.yml`.
+
 ## Run tests
 
 ```


### PR DESCRIPTION
## Summary
- build and deploy DuckDbDemo to GitHub Pages via workflow
- document demo deployment in README

## Testing
- `dotnet test` *(fails: FunctionDeclarationDebugTests, SyntaxAnalysisTests, FunctionBodyDebugTests2, unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_6892565fb7788333b168708769a03cf7